### PR TITLE
fix(oauth): move client secrets from URL query params to POST body

### DIFF
--- a/core/oauth/package.json
+++ b/core/oauth/package.json
@@ -25,11 +25,13 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "handlebars": "^4.7.8",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "qs": "^6.13.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
+    "@types/qs": "^6.9.17",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
     "eslint": "^8.20.0",

--- a/core/oauth/src/connections/jira/init.ts
+++ b/core/oauth/src/connections/jira/init.ts
@@ -12,7 +12,10 @@ export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
         const response = await axios({
             url: 'https://auth.atlassian.com/oauth/token',
             method: 'POST',
-            params: {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            data: {
                 grant_type: 'authorization_code',
                 code,
                 client_id,

--- a/core/oauth/src/connections/jira/refresh.ts
+++ b/core/oauth/src/connections/jira/refresh.ts
@@ -13,7 +13,10 @@ export const refresh = async ({ body }: DataObject): Promise<OAuthResponse> => {
         const response = await axios({
             url: 'https://auth.atlassian.com/oauth/token',
             method: 'POST',
-            params: {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            data: {
                 grant_type: 'refresh_token',
                 refresh_token,
                 client_id,

--- a/core/oauth/src/connections/zoho/init.ts
+++ b/core/oauth/src/connections/zoho/init.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import qs from 'qs';
 import { DataObject, OAuthResponse } from '../../lib/types';
 
 export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
@@ -14,11 +15,22 @@ export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
             additionalData['accounts-server'],
         );
 
-        let url = `${ZOHO_ACCOUNTS_DOMAIN}/oauth/v2/token?grant_type=authorization_code`;
-        url += `&client_id=${clientId}&client_secret=${clientSecret}`;
-        url += `&code=${code}&redirect_uri=${redirectUri}`;
+        const requestBody = {
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            client_secret: clientSecret,
+            code,
+            redirect_uri: redirectUri,
+        };
 
-        const response = await axios.post(url);
+        const response = await axios({
+            url: `${ZOHO_ACCOUNTS_DOMAIN}/oauth/v2/token`,
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            data: qs.stringify(requestBody),
+        });
 
         const {
             data: {

--- a/core/oauth/src/connections/zoho/refresh.ts
+++ b/core/oauth/src/connections/zoho/refresh.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import qs from 'qs';
 import { DataObject, OAuthResponse } from '../../lib/types';
 
 export const refresh = async ({ body }: DataObject): Promise<OAuthResponse> => {
@@ -13,10 +14,21 @@ export const refresh = async ({ body }: DataObject): Promise<OAuthResponse> => {
         let refreshToken = refresh_token;
         const ZOHO_ACCOUNTS_DOMAIN = meta.ZOHO_ACCOUNTS_DOMAIN;
 
-        let url = `${ZOHO_ACCOUNTS_DOMAIN}/oauth/v2/token?grant_type=refresh_token`;
-        url += `&client_id=${client_id}&client_secret=${client_secret}&refresh_token=${refresh_token}`;
+        const requestBody = {
+            grant_type: 'refresh_token',
+            client_id,
+            client_secret,
+            refresh_token,
+        };
 
-        const response = await axios.post(url);
+        const response = await axios({
+            url: `${ZOHO_ACCOUNTS_DOMAIN}/oauth/v2/token`,
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            data: qs.stringify(requestBody),
+        });
 
         const {
             data: {


### PR DESCRIPTION
This pull request updates the OAuth flows for Jira and Zoho integrations to use form-encoded POST requests instead of query parameters, improving standards compliance and security. It also introduces the `qs` library for request serialization and updates dependencies accordingly.

**Dependency updates:**

* Added `qs` and its type definitions to `core/oauth/package.json` for request body serialization.

**Jira integration improvements:**

* Updated `core/oauth/src/connections/jira/init.ts` to use a form-encoded POST request for token exchange, replacing the previous use of query parameters. [[1]](diffhunk://#diff-20dd9606947fcbcf1052c029563e231d49836e027ee329adb31aa1609d1169d8R2) [[2]](diffhunk://#diff-20dd9606947fcbcf1052c029563e231d49836e027ee329adb31aa1609d1169d8L12-R27)
* Updated `core/oauth/src/connections/jira/refresh.ts` to use a form-encoded POST request for token refresh. [[1]](diffhunk://#diff-52a774b1057238781e2362c3bfa749f5fc0717d4ddf09aa998576ce57a61825cR2) [[2]](diffhunk://#diff-52a774b1057238781e2362c3bfa749f5fc0717d4ddf09aa998576ce57a61825cL13-R27)

**Zoho integration improvements:**

* Updated `core/oauth/src/connections/zoho/init.ts` to use a form-encoded POST request for token exchange, replacing the previous use of query parameters. [[1]](diffhunk://#diff-ecb3bde8d4cce1fcfb7212a0373670f2e7935128ac9a7338d1cfa96107a6593aR2) [[2]](diffhunk://#diff-ecb3bde8d4cce1fcfb7212a0373670f2e7935128ac9a7338d1cfa96107a6593aL17-R33)
* Updated `core/oauth/src/connections/zoho/refresh.ts` to use a form-encoded POST request for token refresh. [[1]](diffhunk://#diff-6892ee7c158072dace2fe5e0f6e0ddfa3c4997249e9e42ed2c036cc5b84ccb83R2) [[2]](diffhunk://#diff-6892ee7c158072dace2fe5e0f6e0ddfa3c4997249e9e42ed2c036cc5b84ccb83L16-R31)